### PR TITLE
chore: Added a new Release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Docker Hub + Github Packages
 on:
   workflow_dispatch:
   push:
-    branches: ["master"]
+    branches: ["main"]
     # Publish semver tags as releases.
     tags: ["*.*.*"]
 


### PR DESCRIPTION
Hey @PanSalut! Great work! Was hoping to test this out but there isn't an amd64 build. This will allow you to utilize github actions for free to build it for you and deploy to ghcr.io

All that will need to be configured on the origin end is a new secret `GITHUB_TOKEN` that is a Never expiring Github PAT from the origin's owner.