### PR TITLE
Fix: use lowercase image name for ghcr.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/PanSalut/koffan
+            ghcr.io/pansalut/koffan
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
## Summary

- Fix Docker image push failure by using lowercase image name for ghcr.io
- ghcr.io requires lowercase names, but the workflow used `ghcr.io/PanSalut/koffan` instead of `ghcr.io/pansalut/koffan`
- This was causing `permission_denied: write_package` errors during the push step

## Test plan

- [ ] Merge PR and verify GitHub Actions workflow succeeds
- [ ] Verify multi-arch image (amd64 + arm64) is pushed to ghcr.io

Fixes #21