### PR TITLE
Add support for long list names (styling)

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -31,10 +31,10 @@
             <h2 class="text-lg font-semibold text-stone-800 mb-4" x-text="t('lists.title')"></h2>
 
             <!-- Lists grid -->
-            <div class="grid gap-3" id="lists-container">
+            <div class="flex flex-wrap gap-3" id="lists-container">
                 {{range .Lists}}
                 <div
-                    class="relative bg-white rounded-xl border border-stone-200 p-4 flex items-center gap-4 hover:border-pink-200 hover:shadow-md transition-all group"
+                    class="relative bg-white rounded-xl border border-stone-200 p-4 flex items-center gap-4 hover:border-pink-200 hover:shadow-md transition-all group w-full"
                     x-data="{ showActions: false }"
                 >
                     <!-- Icon -->

--- a/templates/list.html
+++ b/templates/list.html
@@ -3,16 +3,16 @@
     <!-- Header -->
     <header class="sticky top-0 z-30 bg-stone-50 pt-3">
         <div class="container mx-auto max-w-4xl px-4">
-            <div class="flex items-center justify-between h-14 mb-4">
+            <div class="flex items-center justify-between h-14 mb-4 gap-3">
                 <!-- Logo and List Name -->
-                <div class="flex items-center gap-3">
-                    <a href="/" class="hover:opacity-80 transition-opacity" title="Powrót do list">
+                <div class="flex items-center gap-3 overflow-hidden">
+                    <a href="/" class="hover:opacity-80 transition-opacity flex-shrink-0" title="Powrót do list">
                         <img src="/static/koffan-logo.webp" alt="Koffan Logo" class="h-10">
                     </a>
                     <span class="text-stone-300">/</span>
-                    <div class="flex items-center gap-2">
+                    <div class="flex items-center gap-2 overflow-hidden">
                         {{if .List}}<span class="text-xl">{{.List.Icon}}</span>{{end}}
-                        <h1 class="text-lg font-semibold text-stone-800 truncate max-w-32 md:max-w-48">{{if .List}}{{.List.Name}}{{else}}Lista zakupów{{end}}</h1>
+                        <h1 class="text-lg font-semibold text-stone-800 truncate" title="{{if .List}}{{.List.Name}}{{else}}Lista zakupów{{end}}">{{if .List}}{{.List.Name}}{{else}}Lista zakupów{{end}}</h1>
                     </div>
                 </div>
 


### PR DESCRIPTION
Updated classnames to support longer names for lists. It now truncates the list name only when it does not fit into the container.

<img width="913" height="474" alt="image" src="https://github.com/user-attachments/assets/128d3c77-4d34-4afa-93b1-ee8a16169c76" />
<img width="913" height="373" alt="image" src="https://github.com/user-attachments/assets/a1708996-71d0-47e9-bb8f-f1d437634d68" />
<img width="913" height="339" alt="image" src="https://github.com/user-attachments/assets/df1a99b7-c917-43d5-bf0e-1f8facc5bb9e" />

Let me know if gap sizes needs adjusting

