### PR TITLE
Remove copying of templates and static files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,6 @@ RUN apk --no-cache add ca-certificates tzdata libc6-compat
 # Copy binary from builder
 COPY --from=builder /app/shopping-list .
 
-# Copy templates and static files
-COPY --from=builder /app/templates ./templates
-COPY --from=builder /app/static ./static
-
 # Create data directory for database
 RUN mkdir -p /data
 


### PR DESCRIPTION
Don't copy templates and static files since they are now embedded into the binary.