### PR TITLE
Fix Service Worker path

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -376,7 +376,7 @@
     <script>
         // Register Service Worker with update handling
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/sw.js?v=5')
+            navigator.serviceWorker.register('/static/sw.js?v=5')
                 .then(reg => {
                     console.log('[App] Service Worker registered:', reg.scope);
                     // Force update check


### PR DESCRIPTION
I wasn't able to get Koffan working offline. After some debugging I noticed the following error in the console:
<img width="1760" height="60" alt="image" src="https://github.com/user-attachments/assets/5d0bf103-a899-4e7e-a1e2-3987390c862c" />

It seems the `static` path prefix was missing for `sw.js`.

After correcting this, the error is gone:
<img width="608" height="46" alt="image" src="https://github.com/user-attachments/assets/4e964ba6-eec5-443a-b891-076b4e6192f5" />

<img width="1423" height="360" alt="image" src="https://github.com/user-attachments/assets/ae2a73af-99fb-46b8-81ad-e0792f6d674d" />

Validated on:
- Koffan v1.8.1
- Firefox 147.0.1