### PR TITLE
fix: en lang, 'settings' section is duplicated

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -75,13 +75,15 @@
     "report_bug": "Found a bug? Let me know!",
     "tab_account": "Account",
     "tab_shopping_list": "Shopping list",
+    "tab_data": "Data",
     "delete_completed": "Delete all bought items",
     "delete_completed_description": "Removes all items marked as bought from the shopping list.",
     "history_section_mode": "Section for history suggestions",
     "use_first_section": "Use first section",
     "use_first_section_desc": "If section doesn't exist, add to first available",
     "auto_create_section": "Auto-create section",
-    "auto_create_section_desc": "If section doesn't exist, create a new one with the same name"
+    "auto_create_section_desc": "If section doesn't exist, create a new one with the same name",
+    "update_available": "New version available"
   },
   "login": {
     "title": "Login - Koffan",
@@ -166,28 +168,6 @@
     "feature_sections": "Sections",
     "feature_templates": "Real-time",
     "feature_offline": "Offline"
-  },
-  "settings": {
-    "title": "Settings",
-    "theme": "Theme",
-    "theme_light": "Light",
-    "theme_dark": "Dark",
-    "theme_system": "System",
-    "language": "Language",
-    "coming_soon": "Coming soon...",
-    "sponsor": "Want to support the app? Add to cart!",
-    "report_bug": "Found a bug? Let me know!",
-    "tab_account": "Account",
-    "tab_shopping_list": "Shopping list",
-    "tab_data": "Data",
-    "delete_completed": "Delete all bought items",
-    "delete_completed_description": "Removes all items marked as bought from the shopping list.",
-    "history_section_mode": "Section for history suggestions",
-    "use_first_section": "Use first section",
-    "use_first_section_desc": "If section doesn't exist, add to first available",
-    "auto_create_section": "Auto-create section",
-    "auto_create_section_desc": "If section doesn't exist, create a new one with the same name",
-    "update_available": "New version available"
   },
   "export": {
     "title": "Export Data",


### PR DESCRIPTION
When translating the program to Russian, I discovered that the English version file (`en.json`) contains a duplicate `settings` section.

I chose the upper section as the main one, since it is also at the top in other localization files (line 66).
I deleted the lower section and moved the new items to the upper section.