### PR TITLE
Remove _fullRefreshUntil suppression window that caused mobile taps to silently no-op

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -293,7 +293,6 @@ function shoppingList() {
         _refreshStatsTimer: null,
         _isRefreshing: false,
         _suppressOverlayUntil: 0, // Timestamp until which overlay should be suppressed
-        _fullRefreshUntil: 0, // Timestamp until which individual section refreshes are suppressed
 
         // Check if add-item form is currently active (to prevent dropdown updates during form use)
         _isAddFormActive() {
@@ -633,9 +632,6 @@ function shoppingList() {
         async fullRefresh() {
             console.log('[App] Full refresh triggered');
 
-            // Suppress individual section refreshes during full refresh to prevent race conditions
-            this._fullRefreshUntil = Date.now() + 3000;
-
             // Reconnect WebSocket if needed
             const wsOpen = this.ws && this.ws.readyState === WebSocket.OPEN;
             if (!wsOpen && this.isOnline) {
@@ -778,12 +774,6 @@ function shoppingList() {
             try {
                 const message = JSON.parse(data);
                 console.log('WebSocket message:', message.type);
-
-                // Skip refresh-triggering messages during full refresh (background return)
-                if (Date.now() < this._fullRefreshUntil && message.type !== 'pong') {
-                    console.log(`[App] Skipping WebSocket message '${message.type}' - full refresh in progress`);
-                    return;
-                }
 
                 const sectionId = message.data?.section_id;
 
@@ -1003,7 +993,7 @@ function shoppingList() {
                     for (const section of sections) {
                         const el = document.getElementById(`section-${section.id}`);
                         if (el) {
-                            await this.refreshSection(section.id, { force: true });
+                            await this.refreshSection(section.id);
                         } else {
                             const r = await fetch(`/sections/${section.id}/html`);
                             if (r.ok) {
@@ -1070,12 +1060,7 @@ function shoppingList() {
             }
         },
 
-        async refreshSection(sectionId, opts = {}) {
-            // Skip if a full refresh is in progress (prevents race conditions)
-            if (!opts.force && Date.now() < this._fullRefreshUntil) {
-                console.log(`[App] Skipping refreshSection(${sectionId}) - full refresh in progress`);
-                return;
-            }
+        async refreshSection(sectionId) {
             const section = document.getElementById(`section-${sectionId}`);
             if (!section) return;
 


### PR DESCRIPTION
On mobile, checking a list item within ~3 seconds of reopening the browser would succeed server-side but never update the UI — requiring 2–3 taps to visually register a change.

## Root cause

`fullRefresh()` (triggered by `visibilitychange`) set a 3-second suppression window that blocked both `refreshSection()` calls and all incoming WebSocket messages:

```js
// fullRefresh() — set a 3-second dead zone
this._fullRefreshUntil = Date.now() + 3000;

// handleMessage() — silently dropped every WS message during it
if (Date.now() < this._fullRefreshUntil && message.type !== 'pong') return;

// refreshSection() — silently no-oped unless called with { force: true }
if (!opts.force && Date.now() < this._fullRefreshUntil) return;
```

A successful toggle would call `refreshSection()` without `force`, get silently skipped, and leave the UI stale. Each subsequent tap toggled the server state back and forth with no visual feedback until the window expired.

## Why the window is unnecessary

- The WebSocket server (`handlers/ws.go`) is a live-only broadcast — no message buffering. Reconnecting clients receive nothing queued; there is no burst of replayed messages to guard against.
- The existing `pendingLocalActions`/`isLocalAction` 1-second per-action-type window already deduplicates WS echoes of local actions.
- `refreshList` has its own `_isRefreshing` mutex preventing concurrent full-list refreshes.
- Any WS-triggered `refreshSection` running concurrently with `fullRefresh` is harmless — both replace the same DOM node with fresh server HTML.

## Changes

- **Removed `_fullRefreshUntil`** — property declaration, the setter in `fullRefresh()`, the guard in `handleMessage()`, and the guard + `opts` parameter in `refreshSection()`
- **Cleaned up call sites** — removed all `{ force: true }` arguments that existed only to bypass the now-deleted mechanism

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.