### PR TITLE
Feature: add crossorigin="use-credentials" to manifest for PWA support behind proxies

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/png" href="/static/icon-192.png" sizes="192x192">
     <link rel="icon" href="/static/favicon.ico" sizes="48x48">
     <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
-    <link rel="manifest" href="/static/manifest.json">
+    <link rel="manifest" href="/static/manifest.json" crossorigin="use-credentials">
     <meta name="theme-color" content="#f9a8d4">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 


### PR DESCRIPTION
## Overview
This PR adds the `crossorigin="use-credentials"` attribute to the webmanifest link in the HTML header.

## Why is this needed?
When running Koffan behind a reverse proxy or a tunnel (like Cloudflare Tunnel, Tailscale, or NetBird) that requires authentication, the browser attempts to fetch the manifest anonymously by default. This causes the proxy to block the request, preventing the PWA from being correctly installed on mobile devices.

By adding `crossorigin="use-credentials"`, the browser sends the necessary session cookies, allowing the PWA to initialize properly in secure self-hosted environments.

## Related Issues
Fixes #114
Relates to #84