### PR TITLE
new config: disable "check/uncheck all" UI feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ docker-compose up -d
 | `LOGIN_WINDOW_MINUTES` | `15` | Time window for counting attempts |
 | `LOGIN_LOCKOUT_MINUTES` | `30` | Lockout duration after exceeding limit |
 | `API_TOKEN` | *(disabled)* | Enable REST API with this token ([docs](https://github.com/PanSalut/Koffan/wiki/REST-API)) |
+| `DISABLE_CHECK_ALL` | `false` | Set to `true` to disable and hide the "Check all" feature in the UI (does not affect API endpoint) |
+| `DISABLE_UNCHECK_ALL` | `false` | Set to `true` to disable and hide the "Uncheck all" feature in the UI (does not affect API endpoint) |
 
 ## Deploy to Your Server
 

--- a/api/api.go
+++ b/api/api.go
@@ -43,9 +43,9 @@ func Register(app *fiber.App) {
 	v1.Get("/sections/:id/items", GetSectionItems)
 	v1.Post("/sections/:id/move-up", MoveSectionUp)
 	v1.Post("/sections/:id/move-down", MoveSectionDown)
+	v1.Post("/sections/:id/sort-mode", UpdateSectionSortMode)
 	v1.Post("/sections/:id/check-all", CheckAllItems)
 	v1.Post("/sections/:id/uncheck-all", UncheckAllItems)
-	v1.Post("/sections/:id/sort-mode", UpdateSectionSortMode)
 
 	// Items endpoints
 	v1.Get("/items/:id", GetItem)

--- a/handlers/lists.go
+++ b/handlers/lists.go
@@ -317,8 +317,10 @@ func ToggleShowCompleted(c *fiber.Ctx) error {
 // sectionRenderMap builds the template data map for rendering a single section partial
 func sectionRenderMap(section *db.Section) fiber.Map {
 	return fiber.Map{
-		"Section":       section,
-		"Sections":      getSectionsForDropdown(),
-		"ShowCompleted": db.GetShowCompletedForSection(section.ID),
+		"Section":           section,
+		"Sections":          getSectionsForDropdown(),
+		"ShowCompleted":     db.GetShowCompletedForSection(section.ID),
+		"DisableCheckAll":   IsCheckAllDisabled(),
+		"DisableUncheckAll": IsUncheckAllDisabled(),
 	}
 }

--- a/handlers/sections.go
+++ b/handlers/sections.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"os"
 	"shopping-list/db"
 	"shopping-list/i18n"
 	"strconv"
@@ -10,6 +11,18 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 )
+
+// IsCheckAllDisabled returns true, if the DISABLE_CHECK_ALL environment variable is set to "true".
+// Then, the "Check All" feature will be disabled in the UI.
+func IsCheckAllDisabled() bool {
+	return os.Getenv("DISABLE_CHECK_ALL") == "true"
+}
+
+// IsUncheckAllDisabled returns true, if the DISABLE_UNCHECK_ALL environment variable is set to "true".
+// Then, the "Uncheck All" feature will be disabled in the UI.
+func IsUncheckAllDisabled() bool {
+	return os.Getenv("DISABLE_UNCHECK_ALL") == "true"
+}
 
 var ErrInvalidListID = errors.New("invalid list_id")
 

--- a/main.go
+++ b/main.go
@@ -202,9 +202,14 @@ func main() {
 	app.Delete("/sections/:id", handlers.DeleteSection)
 	app.Post("/sections/:id/move-up", handlers.MoveSectionUp)
 	app.Post("/sections/:id/move-down", handlers.MoveSectionDown)
-	app.Post("/sections/:id/check-all", handlers.CheckAllItems)
-	app.Post("/sections/:id/uncheck-all", handlers.UncheckAllItems)
 	app.Post("/sections/:id/sort-mode", handlers.UpdateSectionSortMode)
+
+	if handlers.IsCheckAllDisabled() {
+		app.Post("/sections/:id/check-all", handlers.CheckAllItems)
+	}
+	if handlers.IsUncheckAllDisabled() {
+		app.Post("/sections/:id/uncheck-all", handlers.UncheckAllItems)
+	}
 
 	// Lists API
 	app.Get("/lists", handlers.GetLists)

--- a/templates/partials/section.html
+++ b/templates/partials/section.html
@@ -35,7 +35,7 @@
             <span x-show="!editingSection" class="text-xs text-stone-400 dark:text-stone-500 section-counter flex-shrink-0">{{$completedItems}}/{{$totalItems}}</span>
         </div>
         <div class="flex items-center gap-2 flex-shrink-0">
-            {{if eq $percentage 100}}
+            {{if and .DisableUncheckAll (eq $percentage 100)}}
             <!-- Completed checkmark icon - clickable to uncheck all -->
             <button @click="toggleAllItems({{.Section.ID}})"
                 x-show="!editingSection"
@@ -47,7 +47,7 @@
             </button>
             {{end}}
             <!-- Check all button - only when there are active items -->
-            {{if gt $activeItems 0}}
+            {{if and .DisableCheckAll (gt $activeItems 0)}}
             <button
                 @click="toggleAllItems({{.Section.ID}})"
                 x-show="!editingSection"


### PR DESCRIPTION
new config: disable "check/uncheck all" UI feature

This prevents accidentally triggering it if the feature is not used by any users. This is a rather "forceful" solution - though for my use cases and users I prefer this, over a "lighter touch" by using e.g., a "Are you sure?" confirmation dialog.