### PR TITLE
feat: add outbound item webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,47 @@ docker-compose up -d
 | `LOGIN_WINDOW_MINUTES` | `15` | Time window for counting attempts |
 | `LOGIN_LOCKOUT_MINUTES` | `30` | Lockout duration after exceeding limit |
 | `API_TOKEN` | *(disabled)* | Enable REST API with this token ([docs](https://github.com/PanSalut/Koffan/wiki/REST-API)) |
+| `WEBHOOK_URL` | *(disabled)* | HTTP or HTTPS endpoint for outbound item events |
+| `WEBHOOK_SECRET` | *(none)* | Secret used to sign webhook payloads with HMAC-SHA256 |
+| `WEBHOOK_EVENTS` | *(all item events)* | Comma-separated filter: `item.created`, `item.updated`, `item.completed`, `item.deleted` |
+
+### Outbound Webhooks
+
+Set `WEBHOOK_URL` to receive asynchronous HTTP POST notifications when items change. Webhook failures are logged and do not interrupt list operations.
+
+```bash
+WEBHOOK_URL=https://automation.example.com/webhook/koffan \
+WEBHOOK_SECRET=replace-with-a-random-secret \
+WEBHOOK_EVENTS=item.created,item.completed,item.deleted \
+go run .
+```
+
+Each request includes `Content-Type: application/json`, an `X-Koffan-Event` header, and a JSON body:
+
+```json
+{
+  "event": "item.created",
+  "timestamp": "2026-08-01T10:30:00Z",
+  "data": {
+    "item": {
+      "id": 42,
+      "section_id": 3,
+      "name": "Milk",
+      "description": "",
+      "completed": false,
+      "uncertain": false,
+      "quantity": 1,
+      "sort_order": 0,
+      "created_at": "2026-08-01T10:30:00Z",
+      "updated_at": 1785580200
+    },
+    "section": {"id": 3, "name": "Dairy"},
+    "list": {"id": 1, "name": "Weekly groceries"}
+  }
+}
+```
+
+When `WEBHOOK_SECRET` is set, Koffan adds `X-Koffan-Signature-256: sha256=<hex digest>`. Verify it by computing HMAC-SHA256 over the raw request body with the same secret. If `WEBHOOK_EVENTS` is omitted, all four supported events are delivered.
 
 ## Deploy to Your Server
 

--- a/api/batch.go
+++ b/api/batch.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"shopping-list/db"
 	"shopping-list/handlers"
+	"shopping-list/webhook"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -153,6 +154,7 @@ func batchCreateNewList(c *fiber.Ctx, req BatchCreateRequest) error {
 	handlers.BroadcastUpdate("batch_created", map[string]interface{}{
 		"list_id": list.ID,
 	})
+	handlers.NotifyItemWebhooks(webhook.EventItemCreated, items, nil)
 
 	return c.Status(fiber.StatusCreated).JSON(BatchCreateResponse{
 		List:     list,
@@ -265,6 +267,7 @@ func batchAddToList(c *fiber.Ctx, req BatchCreateRequest) error {
 	handlers.BroadcastUpdate("batch_created", map[string]interface{}{
 		"list_id": req.ListID,
 	})
+	handlers.NotifyItemWebhooks(webhook.EventItemCreated, items, nil)
 
 	return c.Status(fiber.StatusCreated).JSON(BatchCreateResponse{
 		Sections: sections,
@@ -346,6 +349,7 @@ func batchAddToSection(c *fiber.Ctx, req BatchCreateRequest) error {
 	handlers.BroadcastUpdate("batch_created", map[string]interface{}{
 		"section_id": req.SectionID,
 	})
+	handlers.NotifyItemWebhooks(webhook.EventItemCreated, items, nil)
 
 	return c.Status(fiber.StatusCreated).JSON(BatchCreateResponse{
 		Items: items,

--- a/api/items.go
+++ b/api/items.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"shopping-list/db"
 	"shopping-list/handlers"
+	"shopping-list/webhook"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -122,6 +123,7 @@ func CreateItem(c *fiber.Ctx) error {
 			}
 			db.SaveItemHistory(req.Name, req.SectionID)
 			handlers.BroadcastUpdate("item_toggled", item)
+			handlers.NotifyItemWebhook(webhook.EventItemUpdated, item)
 			return c.JSON(fiber.Map{
 				"item":        item,
 				"reactivated": true,
@@ -146,6 +148,7 @@ func CreateItem(c *fiber.Ctx) error {
 	db.SaveItemHistory(req.Name, req.SectionID)
 
 	handlers.BroadcastUpdate("item_created", item)
+	handlers.NotifyItemWebhook(webhook.EventItemCreated, item)
 	return c.Status(fiber.StatusCreated).JSON(item)
 }
 
@@ -220,6 +223,7 @@ func UpdateItem(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("item_updated", item)
+	handlers.NotifyItemWebhook(webhook.EventItemUpdated, item)
 	return c.JSON(item)
 }
 
@@ -234,7 +238,7 @@ func DeleteItem(c *fiber.Ctx) error {
 	}
 
 	// Check if item exists
-	_, err = db.GetItemByID(int64(id))
+	item, err := db.GetItemByID(int64(id))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{
@@ -256,6 +260,7 @@ func DeleteItem(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("item_deleted", map[string]int64{"id": int64(id)})
+	handlers.NotifyItemWebhook(webhook.EventItemDeleted, item)
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -293,6 +298,11 @@ func ToggleItemCompleted(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("item_toggled", item)
+	event := webhook.EventItemUpdated
+	if item.Completed {
+		event = webhook.EventItemCompleted
+	}
+	handlers.NotifyItemWebhook(event, item)
 	return c.JSON(item)
 }
 
@@ -330,6 +340,7 @@ func ToggleItemUncertain(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("item_updated", item)
+	handlers.NotifyItemWebhook(webhook.EventItemUpdated, item)
 	return c.JSON(item)
 }
 
@@ -375,6 +386,7 @@ func AdjustItemQuantity(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("item_updated", item)
+	handlers.NotifyItemWebhook(webhook.EventItemUpdated, item)
 	return c.JSON(item)
 }
 
@@ -442,6 +454,7 @@ func MoveItem(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("item_moved", item)
+	handlers.NotifyItemWebhook(webhook.EventItemUpdated, item)
 	return c.JSON(item)
 }
 
@@ -480,6 +493,7 @@ func MoveItemUp(c *fiber.Ctx) error {
 	handlers.BroadcastUpdate("items_reordered", map[string]int64{"section_id": item.SectionID})
 
 	updatedItem, _ := db.GetItemByID(int64(id))
+	handlers.NotifyItemWebhook(webhook.EventItemUpdated, updatedItem)
 	return c.JSON(updatedItem)
 }
 
@@ -518,5 +532,6 @@ func MoveItemDown(c *fiber.Ctx) error {
 	handlers.BroadcastUpdate("items_reordered", map[string]int64{"section_id": item.SectionID})
 
 	updatedItem, _ := db.GetItemByID(int64(id))
+	handlers.NotifyItemWebhook(webhook.EventItemUpdated, updatedItem)
 	return c.JSON(updatedItem)
 }

--- a/api/lists.go
+++ b/api/lists.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"shopping-list/db"
 	"shopping-list/handlers"
+	"shopping-list/webhook"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -239,6 +240,7 @@ func DeleteList(c *fiber.Ctx) error {
 		})
 	}
 
+	preparedWebhooks := handlers.PrepareItemWebhooks(webhook.EventItemDeleted, handlers.SnapshotListItems(int64(id)))
 	if err := db.DeleteList(int64(id)); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
 			Error:   "delete_failed",
@@ -247,6 +249,7 @@ func DeleteList(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("list_deleted", map[string]int64{"id": int64(id)})
+	handlers.NotifyPreparedItemWebhooks(webhook.EventItemDeleted, preparedWebhooks)
 	return c.SendStatus(fiber.StatusNoContent)
 }
 

--- a/api/sections.go
+++ b/api/sections.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"shopping-list/db"
 	"shopping-list/handlers"
+	"shopping-list/webhook"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -144,7 +145,7 @@ func UpdateSection(c *fiber.Ctx) error {
 	}
 
 	// Check if section exists
-	_, err = db.GetSectionByID(int64(id))
+	section, err := db.GetSectionByID(int64(id))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{
@@ -158,7 +159,7 @@ func UpdateSection(c *fiber.Ctx) error {
 		})
 	}
 
-	section, err := db.UpdateSection(int64(id), req.Name)
+	section, err = db.UpdateSection(int64(id), req.Name)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
 			Error:   "update_failed",
@@ -181,7 +182,7 @@ func DeleteSection(c *fiber.Ctx) error {
 	}
 
 	// Check if section exists
-	_, err = db.GetSectionByID(int64(id))
+	section, err := db.GetSectionByID(int64(id))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{
@@ -195,6 +196,7 @@ func DeleteSection(c *fiber.Ctx) error {
 		})
 	}
 
+	preparedWebhooks := handlers.PrepareItemWebhooks(webhook.EventItemDeleted, section.Items)
 	if err := db.DeleteSection(int64(id)); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
 			Error:   "delete_failed",
@@ -203,6 +205,7 @@ func DeleteSection(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("section_deleted", map[string]int64{"id": int64(id)})
+	handlers.NotifyPreparedItemWebhooks(webhook.EventItemDeleted, preparedWebhooks)
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -349,6 +352,7 @@ func CheckAllItems(c *fiber.Ctx) error {
 		})
 	}
 
+	items := handlers.SnapshotItemsByCompletion(int64(id), false)
 	count, err := db.CheckAllItems(int64(id))
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
@@ -358,6 +362,8 @@ func CheckAllItems(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("section_items_checked", map[string]interface{}{"section_id": int64(id), "count": count})
+	completed := true
+	handlers.NotifyItemWebhooks(webhook.EventItemCompleted, items, &completed)
 	return c.JSON(fiber.Map{"count": count, "section_id": id})
 }
 
@@ -385,6 +391,7 @@ func UncheckAllItems(c *fiber.Ctx) error {
 		})
 	}
 
+	items := handlers.SnapshotItemsByCompletion(int64(id), true)
 	count, err := db.UncheckAllItems(int64(id))
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
@@ -394,6 +401,8 @@ func UncheckAllItems(c *fiber.Ctx) error {
 	}
 
 	handlers.BroadcastUpdate("section_items_unchecked", map[string]interface{}{"section_id": int64(id), "count": count})
+	completed := false
+	handlers.NotifyItemWebhooks(webhook.EventItemUpdated, items, &completed)
 	return c.JSON(fiber.Map{"count": count, "section_id": id})
 }
 

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -8,6 +8,9 @@ services:
       - APP_PASSWORD=${APP_PASSWORD:-shopping123}
       - PORT=8080
       - DB_PATH=/data/shopping.db
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
+      - WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
+      - WEBHOOK_EVENTS=${WEBHOOK_EVENTS:-}
     volumes:
       - shopping-data:/data
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,9 @@ services:
       - APP_PASSWORD=${APP_PASSWORD:-shopping123}
       - PORT=8080
       - DB_PATH=/data/shopping.db
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
+      - WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
+      - WEBHOOK_EVENTS=${WEBHOOK_EVENTS:-}
     volumes:
       - shopping-data:/data
     restart: unless-stopped

--- a/handlers/items.go
+++ b/handlers/items.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log"
 	"shopping-list/db"
+	"shopping-list/webhook"
 	"strconv"
 	"strings"
 	"time"
@@ -82,6 +83,7 @@ func CreateItem(c *fiber.Ctx) error {
 			db.SaveItemHistory(name, sectionID)
 			c.Set("X-Item-Reactivated", "true")
 			BroadcastUpdate("item_toggled", item)
+			NotifyItemWebhook(webhook.EventItemUpdated, item)
 			c.Set("HX-Trigger-After-Settle", `{"statsRefresh":"true"}`)
 			return c.Render("partials/item", fiber.Map{
 				"Item":     item,
@@ -104,6 +106,7 @@ func CreateItem(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("item_created", item)
+	NotifyItemWebhook(webhook.EventItemCreated, item)
 
 	c.Set("HX-Trigger-After-Settle", `{"statsRefresh":"true"}`)
 
@@ -163,6 +166,7 @@ func UpdateItem(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("item_updated", item)
+	NotifyItemWebhook(webhook.EventItemUpdated, item)
 
 	// Return individual item partial for smooth per-item swap
 	c.Set("HX-Trigger-After-Settle", `{"statsRefresh":"true"}`)
@@ -196,12 +200,22 @@ func DeleteItem(c *fiber.Ctx) error {
 	}
 
 	BroadcastUpdate("item_deleted", map[string]int64{"id": id, "section_id": item.SectionID})
+	NotifyItemWebhook(webhook.EventItemDeleted, item)
 
 	return c.SendStatus(200)
 }
 
 // DeleteCompletedItems deletes all completed items
 func DeleteCompletedItems(c *fiber.Ctx) error {
+	var completedItems []db.Item
+	if activeList, activeListErr := db.GetActiveList(); activeListErr == nil {
+		for _, item := range SnapshotListItems(activeList.ID) {
+			if item.Completed {
+				completedItems = append(completedItems, item)
+			}
+		}
+	}
+
 	count, err := db.DeleteCompletedItems()
 	if err != nil {
 		return sendError(c, 500, "error.delete_failed")
@@ -209,6 +223,7 @@ func DeleteCompletedItems(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("completed_items_deleted", map[string]int64{"count": count})
+	NotifyItemWebhooks(webhook.EventItemDeleted, completedItems, nil)
 
 	c.Set("HX-Trigger-After-Settle", `{"statsRefresh":"true"}`)
 	return c.JSON(fiber.Map{"deleted": count})
@@ -228,6 +243,11 @@ func ToggleItem(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("item_toggled", item)
+	event := webhook.EventItemUpdated
+	if item.Completed {
+		event = webhook.EventItemCompleted
+	}
+	NotifyItemWebhook(event, item)
 
 	// Return per-item partial (no section swap - client handles DOM move)
 	if item.Completed {
@@ -256,6 +276,7 @@ func ToggleUncertain(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("item_updated", item)
+	NotifyItemWebhook(webhook.EventItemUpdated, item)
 
 	// Return individual item partial for smooth per-item swap
 	if item.Completed {
@@ -299,6 +320,7 @@ func AdjustItemQuantity(c *fiber.Ctx) error {
 	}
 
 	BroadcastUpdate("item_updated", item)
+	NotifyItemWebhook(webhook.EventItemUpdated, item)
 
 	if item.Completed {
 		return c.Render("partials/item_completed", fiber.Map{
@@ -362,6 +384,7 @@ func MoveItemToSection(c *fiber.Ctx) error {
 		"section_id":      item.SectionID,
 		"from_section_id": fromSectionID,
 	})
+	NotifyItemWebhook(webhook.EventItemUpdated, item)
 
 	// Return updated item partial so client can replace stale dropdown
 	c.Set("HX-Trigger-After-Settle", `{"statsRefresh":"true"}`)
@@ -386,6 +409,7 @@ func MoveItemUp(c *fiber.Ctx) error {
 	item, _ := db.GetItemByID(id)
 	if item != nil {
 		BroadcastUpdate("items_reordered", map[string]int64{"section_id": item.SectionID})
+		NotifyItemWebhook(webhook.EventItemUpdated, item)
 	}
 
 	return c.SendStatus(200)
@@ -406,6 +430,7 @@ func MoveItemDown(c *fiber.Ctx) error {
 	item, _ := db.GetItemByID(id)
 	if item != nil {
 		BroadcastUpdate("items_reordered", map[string]int64{"section_id": item.SectionID})
+		NotifyItemWebhook(webhook.EventItemUpdated, item)
 	}
 
 	return c.SendStatus(200)
@@ -451,12 +476,15 @@ func CheckAllItems(c *fiber.Ctx) error {
 		return sendError(c, 400, "error.invalid_section_id")
 	}
 
+	items := SnapshotItemsByCompletion(id, false)
 	count, err := db.CheckAllItems(id)
 	if err != nil {
 		return sendError(c, 500, "error.check_failed")
 	}
 
 	BroadcastUpdate("section_items_checked", map[string]interface{}{"section_id": id, "count": count})
+	completed := true
+	NotifyItemWebhooks(webhook.EventItemCompleted, items, &completed)
 
 	return c.JSON(fiber.Map{"count": count, "section_id": id})
 }
@@ -468,12 +496,15 @@ func UncheckAllItems(c *fiber.Ctx) error {
 		return sendError(c, 400, "error.invalid_section_id")
 	}
 
+	items := SnapshotItemsByCompletion(id, true)
 	count, err := db.UncheckAllItems(id)
 	if err != nil {
 		return sendError(c, 500, "error.check_failed")
 	}
 
 	BroadcastUpdate("section_items_unchecked", map[string]interface{}{"section_id": id, "count": count})
+	completed := false
+	NotifyItemWebhooks(webhook.EventItemUpdated, items, &completed)
 
 	return c.JSON(fiber.Map{"count": count, "section_id": id})
 }

--- a/handlers/lists.go
+++ b/handlers/lists.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"shopping-list/db"
 	"shopping-list/i18n"
+	"shopping-list/webhook"
 	"strconv"
 	"strings"
 
@@ -193,6 +194,7 @@ func DeleteList(c *fiber.Ctx) error {
 		return sendError(c, 400, "error.invalid_id")
 	}
 
+	preparedWebhooks := PrepareItemWebhooks(webhook.EventItemDeleted, SnapshotListItems(id))
 	err = db.DeleteList(id)
 	if err != nil {
 		return c.Status(400).SendString(err.Error())
@@ -200,6 +202,7 @@ func DeleteList(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("list_deleted", map[string]int64{"id": id})
+	NotifyPreparedItemWebhooks(webhook.EventItemDeleted, preparedWebhooks)
 
 	// Return empty string (HTMX will remove the element)
 	return c.SendString("")

--- a/handlers/sections.go
+++ b/handlers/sections.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"shopping-list/db"
 	"shopping-list/i18n"
+	"shopping-list/webhook"
 	"strconv"
 	"strings"
 
@@ -119,6 +120,7 @@ func DeleteSection(c *fiber.Ctx) error {
 		return sendError(c, 400, "error.invalid_id")
 	}
 
+	preparedWebhooks := PrepareItemWebhooks(webhook.EventItemDeleted, SnapshotSectionItems(id))
 	err = db.DeleteSection(id)
 	if err != nil {
 		return sendError(c, 500, "error.delete_failed")
@@ -126,6 +128,7 @@ func DeleteSection(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("section_deleted", map[string]int64{"id": id})
+	NotifyPreparedItemWebhooks(webhook.EventItemDeleted, preparedWebhooks)
 
 	// Return empty string (HTMX will remove the element)
 	return c.SendString("")
@@ -222,6 +225,10 @@ func BatchDeleteSections(c *fiber.Ctx) error {
 		return sendError(c, 400, "error.no_valid_ids")
 	}
 
+	var preparedWebhooks []PreparedItemWebhook
+	for _, id := range ids {
+		preparedWebhooks = append(preparedWebhooks, PrepareItemWebhooks(webhook.EventItemDeleted, SnapshotSectionItems(id))...)
+	}
 	err := db.DeleteSections(ids)
 	if err != nil {
 		return sendError(c, 500, "error.delete_failed")
@@ -229,6 +236,7 @@ func BatchDeleteSections(c *fiber.Ctx) error {
 
 	// Broadcast to WebSocket clients
 	BroadcastUpdate("sections_deleted", map[string]interface{}{"ids": ids})
+	NotifyPreparedItemWebhooks(webhook.EventItemDeleted, preparedWebhooks)
 
 	// Return updated sections list for modal
 	return returnSectionsForModal(c)

--- a/handlers/templates.go
+++ b/handlers/templates.go
@@ -200,6 +200,7 @@ func ApplyTemplate(c *fiber.Ctx) error {
 	if err != nil {
 		return sendError(c, 500, "error.no_active_list")
 	}
+	itemsBefore := SnapshotListItems(activeList.ID)
 
 	err = db.ApplyTemplateToList(templateID, activeList.ID)
 	if err != nil {
@@ -211,6 +212,7 @@ func ApplyTemplate(c *fiber.Ctx) error {
 		"template_id": templateID,
 		"list_id":     activeList.ID,
 	})
+	NotifyCreatedListItems(activeList.ID, itemsBefore)
 
 	// Trigger full refresh - template adds items to multiple sections
 	c.Set("HX-Trigger-After-Settle", `{"statsRefresh":"true","refreshList":"true"}`)

--- a/handlers/webhooks.go
+++ b/handlers/webhooks.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"log"
+	"shopping-list/db"
+	"shopping-list/webhook"
+)
+
+type webhookEntity struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type itemWebhookData struct {
+	Item    *db.Item       `json:"item"`
+	Section *webhookEntity `json:"section,omitempty"`
+	List    *webhookEntity `json:"list,omitempty"`
+}
+
+// PreparedItemWebhook keeps payload context available after a cascading delete.
+type PreparedItemWebhook struct {
+	data itemWebhookData
+}
+
+// NotifyItemWebhook adds list and section context to an item webhook event.
+func NotifyItemWebhook(event string, item *db.Item) {
+	if item == nil || !webhook.Accepts(event) {
+		return
+	}
+	webhook.Notify(event, buildItemWebhookData(event, item))
+}
+
+func buildItemWebhookData(event string, item *db.Item) itemWebhookData {
+	data := itemWebhookData{Item: item}
+	var section webhookEntity
+	var list webhookEntity
+	err := db.DB.QueryRow(`
+		SELECT s.id, s.name, l.id, l.name
+		FROM sections s
+		JOIN lists l ON l.id = s.list_id
+		WHERE s.id = ?
+	`, item.SectionID).Scan(&section.ID, &section.Name, &list.ID, &list.Name)
+	if err != nil {
+		log.Printf("Could not load list context for webhook event %s: %v", event, err)
+	} else {
+		data.Section = &section
+		data.List = &list
+	}
+	return data
+}
+
+// PrepareItemWebhooks captures payload context before a cascading delete.
+func PrepareItemWebhooks(event string, items []db.Item) []PreparedItemWebhook {
+	if !webhook.Accepts(event) {
+		return nil
+	}
+
+	prepared := make([]PreparedItemWebhook, 0, len(items))
+	for index := range items {
+		prepared = append(prepared, PreparedItemWebhook{data: buildItemWebhookData(event, &items[index])})
+	}
+	return prepared
+}
+
+// NotifyPreparedItemWebhooks emits events captured before a cascading delete.
+func NotifyPreparedItemWebhooks(event string, prepared []PreparedItemWebhook) {
+	for _, item := range prepared {
+		webhook.Notify(event, item.data)
+	}
+}
+
+// SnapshotItemsByCompletion captures items before a bulk completion or deletion.
+func SnapshotItemsByCompletion(sectionID int64, completed bool) []db.Item {
+	section, err := db.GetSectionByID(sectionID)
+	if err != nil {
+		log.Printf("Could not snapshot section %d for webhook events: %v", sectionID, err)
+		return nil
+	}
+
+	items := make([]db.Item, 0, len(section.Items))
+	for _, item := range section.Items {
+		if item.Completed == completed {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+// SnapshotSectionItems captures all items in a section before a bulk operation.
+func SnapshotSectionItems(sectionID int64) []db.Item {
+	section, err := db.GetSectionByID(sectionID)
+	if err != nil {
+		log.Printf("Could not snapshot section %d for webhook events: %v", sectionID, err)
+		return nil
+	}
+	return section.Items
+}
+
+// SnapshotListItems captures all items in a list before a bulk operation.
+func SnapshotListItems(listID int64) []db.Item {
+	sections, err := db.GetSectionsByList(listID)
+	if err != nil {
+		log.Printf("Could not snapshot list %d for webhook events: %v", listID, err)
+		return nil
+	}
+
+	var items []db.Item
+	for _, section := range sections {
+		items = append(items, section.Items...)
+	}
+	return items
+}
+
+// NotifyItemWebhooks emits one event for each item affected by a bulk operation.
+func NotifyItemWebhooks(event string, items []db.Item, completed *bool) {
+	for index := range items {
+		if completed != nil {
+			items[index].Completed = *completed
+		}
+		NotifyItemWebhook(event, &items[index])
+	}
+}
+
+// NotifyCreatedListItems emits created events for items added after a snapshot.
+func NotifyCreatedListItems(listID int64, before []db.Item) {
+	existingIDs := make(map[int64]struct{}, len(before))
+	for _, item := range before {
+		existingIDs[item.ID] = struct{}{}
+	}
+
+	for _, item := range SnapshotListItems(listID) {
+		if _, existed := existingIDs[item.ID]; !existed {
+			NotifyItemWebhook(webhook.EventItemCreated, &item)
+		}
+	}
+}

--- a/handlers/webhooks_test.go
+++ b/handlers/webhooks_test.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"shopping-list/db"
+	"shopping-list/webhook"
+	"testing"
+	"time"
+)
+
+type capturedItemWebhook struct {
+	Event string `json:"event"`
+	Data  struct {
+		Item    db.Item       `json:"item"`
+		Section webhookEntity `json:"section"`
+		List    webhookEntity `json:"list"`
+	} `json:"data"`
+}
+
+func TestPreparedItemWebhookKeepsContextAfterSectionDeletion(t *testing.T) {
+	initTestDatabase(t)
+
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		bodies <- body
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	t.Setenv("WEBHOOK_URL", server.URL)
+	t.Setenv("WEBHOOK_EVENTS", webhook.EventItemDeleted)
+	t.Setenv("WEBHOOK_SECRET", "")
+	if err := webhook.ConfigureFromEnv(); err != nil {
+		t.Fatalf("configure webhook: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Setenv("WEBHOOK_URL", "")
+		t.Setenv("WEBHOOK_EVENTS", "")
+		_ = webhook.ConfigureFromEnv()
+	})
+
+	list, err := db.CreateList("Weekly groceries", "cart")
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+	section, err := db.CreateSectionForList(list.ID, "Dairy")
+	if err != nil {
+		t.Fatalf("create section: %v", err)
+	}
+	item, err := db.CreateItem(section.ID, "Milk", "", 1)
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	prepared := PrepareItemWebhooks(webhook.EventItemDeleted, []db.Item{*item})
+	if err := db.DeleteSection(section.ID); err != nil {
+		t.Fatalf("delete section: %v", err)
+	}
+	NotifyPreparedItemWebhooks(webhook.EventItemDeleted, prepared)
+
+	select {
+	case body := <-bodies:
+		var event capturedItemWebhook
+		if err := json.Unmarshal(body, &event); err != nil {
+			t.Fatalf("decode webhook: %v", err)
+		}
+		if event.Event != webhook.EventItemDeleted {
+			t.Errorf("event = %q, want %q", event.Event, webhook.EventItemDeleted)
+		}
+		if event.Data.Item.Name != "Milk" {
+			t.Errorf("item name = %q, want Milk", event.Data.Item.Name)
+		}
+		if event.Data.Section.ID != section.ID || event.Data.Section.Name != "Dairy" {
+			t.Errorf("section = %#v, want deleted Dairy section", event.Data.Section)
+		}
+		if event.Data.List.ID != list.ID || event.Data.List.Name != "Weekly groceries" {
+			t.Errorf("list = %#v, want Weekly groceries list", event.Data.List)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"shopping-list/db"
 	"shopping-list/handlers"
 	"shopping-list/i18n"
+	"shopping-list/webhook"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/compress"
@@ -37,6 +38,10 @@ func main() {
 	// Set default language from env var (if specified)
 	if lang := os.Getenv("DEFAULT_LANG"); lang != "" {
 		i18n.SetDefaultLang(lang)
+	}
+
+	if err := webhook.ConfigureFromEnv(); err != nil {
+		log.Printf("Outbound webhooks are disabled: %v", err)
 	}
 
 	// Initialize database

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -1,0 +1,234 @@
+package webhook
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	EventItemCreated   = "item.created"
+	EventItemUpdated   = "item.updated"
+	EventItemCompleted = "item.completed"
+	EventItemDeleted   = "item.deleted"
+
+	defaultTimeout = 5 * time.Second
+	queueSize      = 256
+)
+
+var supportedEvents = map[string]struct{}{
+	EventItemCreated:   {},
+	EventItemUpdated:   {},
+	EventItemCompleted: {},
+	EventItemDeleted:   {},
+}
+
+// Config controls outbound webhook delivery.
+type Config struct {
+	URL        string
+	Secret     string
+	Events     string
+	Timeout    time.Duration
+	HTTPClient *http.Client
+}
+
+// Event is the JSON envelope sent to the configured endpoint.
+type Event struct {
+	Event     string      `json:"event"`
+	Timestamp time.Time   `json:"timestamp"`
+	Data      interface{} `json:"data"`
+}
+
+type delivery struct {
+	event string
+	body  []byte
+}
+
+// Dispatcher validates, filters, queues, and delivers webhook events.
+type Dispatcher struct {
+	endpoint string
+	secret   string
+	events   map[string]struct{}
+	client   *http.Client
+	queue    chan delivery
+}
+
+var (
+	defaultMu         sync.RWMutex
+	defaultDispatcher = &Dispatcher{}
+)
+
+// New creates a dispatcher. An empty URL returns a disabled dispatcher.
+func New(config Config) (*Dispatcher, error) {
+	if strings.TrimSpace(config.URL) == "" {
+		return &Dispatcher{}, nil
+	}
+
+	parsedURL, err := url.ParseRequestURI(config.URL)
+	if err != nil || parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		return nil, fmt.Errorf("WEBHOOK_URL must be a valid HTTP or HTTPS URL")
+	}
+
+	events, err := parseEvents(config.Events)
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+
+	dispatcher := &Dispatcher{
+		endpoint: parsedURL.String(),
+		secret:   config.Secret,
+		events:   events,
+		client:   client,
+		queue:    make(chan delivery, queueSize),
+	}
+	go dispatcher.run()
+	return dispatcher, nil
+}
+
+// ConfigureFromEnv replaces the package dispatcher using WEBHOOK_URL,
+// WEBHOOK_SECRET, and WEBHOOK_EVENTS.
+func ConfigureFromEnv() error {
+	dispatcher, err := New(Config{
+		URL:    os.Getenv("WEBHOOK_URL"),
+		Secret: os.Getenv("WEBHOOK_SECRET"),
+		Events: os.Getenv("WEBHOOK_EVENTS"),
+	})
+	if err != nil {
+		return err
+	}
+
+	defaultMu.Lock()
+	defaultDispatcher = dispatcher
+	defaultMu.Unlock()
+	return nil
+}
+
+// Enabled reports whether this dispatcher has a configured endpoint.
+func (dispatcher *Dispatcher) Enabled() bool {
+	return dispatcher != nil && dispatcher.endpoint != ""
+}
+
+// Accepts reports whether a particular event would be queued.
+func (dispatcher *Dispatcher) Accepts(event string) bool {
+	if !dispatcher.Enabled() {
+		return false
+	}
+	_, enabled := dispatcher.events[event]
+	return enabled
+}
+
+// Notify queues an event without blocking the item mutation that triggered it.
+// It returns false when delivery is disabled, filtered out, or the queue is full.
+func (dispatcher *Dispatcher) Notify(event string, data interface{}) bool {
+	if !dispatcher.Accepts(event) {
+		return false
+	}
+
+	body, err := json.Marshal(Event{
+		Event:     event,
+		Timestamp: time.Now().UTC(),
+		Data:      data,
+	})
+	if err != nil {
+		log.Printf("Webhook event %s could not be encoded: %v", event, err)
+		return false
+	}
+
+	select {
+	case dispatcher.queue <- delivery{event: event, body: body}:
+		return true
+	default:
+		log.Printf("Webhook queue is full, dropping event %s", event)
+		return false
+	}
+}
+
+// Notify queues an event on the package dispatcher.
+func Notify(event string, data interface{}) bool {
+	defaultMu.RLock()
+	dispatcher := defaultDispatcher
+	defaultMu.RUnlock()
+	return dispatcher.Notify(event, data)
+}
+
+// Accepts reports whether the package dispatcher accepts an event.
+func Accepts(event string) bool {
+	defaultMu.RLock()
+	dispatcher := defaultDispatcher
+	defaultMu.RUnlock()
+	return dispatcher.Accepts(event)
+}
+
+func parseEvents(value string) (map[string]struct{}, error) {
+	if strings.TrimSpace(value) == "" {
+		events := make(map[string]struct{}, len(supportedEvents))
+		for event := range supportedEvents {
+			events[event] = struct{}{}
+		}
+		return events, nil
+	}
+
+	events := make(map[string]struct{})
+	for _, rawEvent := range strings.Split(value, ",") {
+		event := strings.TrimSpace(rawEvent)
+		if _, supported := supportedEvents[event]; !supported {
+			return nil, fmt.Errorf("WEBHOOK_EVENTS contains unsupported event %q", event)
+		}
+		events[event] = struct{}{}
+	}
+	return events, nil
+}
+
+func (dispatcher *Dispatcher) run() {
+	for queued := range dispatcher.queue {
+		if err := dispatcher.deliver(queued); err != nil {
+			log.Printf("Webhook delivery failed for %s: %v", queued.event, err)
+		}
+	}
+}
+
+func (dispatcher *Dispatcher) deliver(queued delivery) error {
+	request, err := http.NewRequest(http.MethodPost, dispatcher.endpoint, bytes.NewReader(queued.body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Koffan-Webhook/1.0")
+	request.Header.Set("X-Koffan-Event", queued.event)
+	if dispatcher.secret != "" {
+		mac := hmac.New(sha256.New, []byte(dispatcher.secret))
+		_, _ = mac.Write(queued.body)
+		request.Header.Set("X-Koffan-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+
+	response, err := dispatcher.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("endpoint returned HTTP %d", response.StatusCode)
+	}
+	return nil
+}

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -1,0 +1,138 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type capturedRequest struct {
+	method string
+	header http.Header
+	body   []byte
+}
+
+func TestNewRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{name: "invalid URL", config: Config{URL: "localhost/webhook"}},
+		{name: "unsupported scheme", config: Config{URL: "ftp://example.com/webhook"}},
+		{name: "unsupported event", config: Config{URL: "https://example.com/webhook", Events: "item.created,list.created"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := New(test.config); err == nil {
+				t.Fatal("New() error = nil, want configuration error")
+			}
+		})
+	}
+}
+
+func TestDisabledDispatcherDoesNotQueueEvents(t *testing.T) {
+	dispatcher, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if dispatcher.Enabled() {
+		t.Fatal("Enabled() = true, want false")
+	}
+	if dispatcher.Notify(EventItemCreated, map[string]string{"name": "Milk"}) {
+		t.Fatal("Notify() = true for disabled dispatcher, want false")
+	}
+}
+
+func TestDispatcherPostsSignedEvent(t *testing.T) {
+	requests := make(chan capturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		requests <- capturedRequest{method: request.Method, header: request.Header.Clone(), body: body}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	dispatcher, err := New(Config{URL: server.URL, Secret: "test-secret"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if !dispatcher.Notify(EventItemCreated, map[string]interface{}{
+		"item": map[string]interface{}{"id": float64(42), "name": "Milk"},
+	}) {
+		t.Fatal("Notify() = false, want true")
+	}
+
+	select {
+	case request := <-requests:
+		if request.method != http.MethodPost {
+			t.Errorf("method = %q, want POST", request.method)
+		}
+		if contentType := request.header.Get("Content-Type"); contentType != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", contentType)
+		}
+		if event := request.header.Get("X-Koffan-Event"); event != EventItemCreated {
+			t.Errorf("X-Koffan-Event = %q, want %q", event, EventItemCreated)
+		}
+
+		mac := hmac.New(sha256.New, []byte("test-secret"))
+		_, _ = mac.Write(request.body)
+		wantSignature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+		if signature := request.header.Get("X-Koffan-Signature-256"); !hmac.Equal([]byte(signature), []byte(wantSignature)) {
+			t.Errorf("signature = %q, want %q", signature, wantSignature)
+		}
+
+		var event Event
+		if err := json.Unmarshal(request.body, &event); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if event.Event != EventItemCreated {
+			t.Errorf("event = %q, want %q", event.Event, EventItemCreated)
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("timestamp is zero")
+		}
+		data, ok := event.Data.(map[string]interface{})
+		if !ok {
+			t.Fatalf("data type = %T, want object", event.Data)
+		}
+		item, ok := data["item"].(map[string]interface{})
+		if !ok || item["name"] != "Milk" {
+			t.Errorf("item = %#v, want Milk", data["item"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook request")
+	}
+}
+
+func TestDispatcherFiltersEvents(t *testing.T) {
+	requests := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests <- struct{}{}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	dispatcher, err := New(Config{URL: server.URL, Events: EventItemDeleted})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if dispatcher.Notify(EventItemCreated, nil) {
+		t.Fatal("Notify(created) = true, want filtered event")
+	}
+	if !dispatcher.Notify(EventItemDeleted, nil) {
+		t.Fatal("Notify(deleted) = false, want queued event")
+	}
+
+	select {
+	case <-requests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for enabled event")
+	}
+}


### PR DESCRIPTION
## Summary

- add asynchronous HTTP POST webhooks for item creation, updates, completion, and deletion
- support event filtering with `WEBHOOK_EVENTS` and HMAC-SHA256 signing with `WEBHOOK_SECRET`
- include item, section, and list context, including cascading and bulk operations
- document environment variables and pass them through Docker Compose

## Testing

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `node --test test/*.test.js`
- `docker compose -f docker-compose.yaml config`
- `docker compose -f docker-compose.local.yaml config`
- localhost REST E2E for create, update, complete, uncomplete, delete, bulk completion, and cascading deletion
- localhost UI E2E for section creation, item creation, completion, and uncompletion
- verified 15 outbound deliveries and all HMAC signatures
- verified event filtering and non-blocking behavior with an unavailable endpoint

Closes #139