### PR TITLE
fix: raise request read buffer size to avoid HTTP 431 behind SSO proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ docker-compose up -d
 | `APP_PASSWORD` | `shopping123` | Login password |
 | `DISABLE_AUTH` | `false` | Set to `true` to disable authentication (for reverse proxy setups) |
 | `PORT` | `8080` (Docker) / `3000` (local) | Server port |
+| `HTTP_READ_BUFFER_SIZE` | `16384` | Max size in bytes for request headers (raise if you see HTTP 431 behind an SSO proxy) |
 | `DB_PATH` | `./shopping.db` | Database file path |
 | `DEFAULT_LANG` | `en` | Default UI language (pl, en, de, es, fr, pt, uk, no, lt, el, sk, ru) |
 | `LOGIN_MAX_ATTEMPTS` | `5` | Max login attempts before lockout |

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"shopping-list/api"
 	"shopping-list/db"
 	"shopping-list/handlers"
@@ -129,10 +130,26 @@ func main() {
 		},
 	})
 
+	// The request read buffer also caps the maximum size of the HTTP
+	// request header block. fasthttp's default of 4 KiB is too small when
+	// Koffan runs behind an SSO reverse proxy, where the browser sends
+	// large cookie headers on every request. Oversized headers are then
+	// rejected with HTTP 431 "Request Header Fields Too Large" before the
+	// app can handle them. Allow operators to raise the limit.
+	readBufferSize := 16384 // 16 KiB default
+	if v := os.Getenv("HTTP_READ_BUFFER_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			readBufferSize = n
+		} else {
+			log.Printf("Invalid HTTP_READ_BUFFER_SIZE %q, using default %d", v, readBufferSize)
+		}
+	}
+
 	// Initialize Fiber app
 	app := fiber.New(fiber.Config{
-		Views:       engine,
-		ViewsLayout: "layout",
+		Views:         engine,
+		ViewsLayout:   "layout",
+		ReadBufferSize: readBufferSize,
 	})
 
 	// Middleware


### PR DESCRIPTION
## Problem

When Koffan runs behind an SSO reverse proxy (e.g. Authelia or Cloudflare Access), the browser sends large cookie headers on every request. fasthttp — the HTTP engine behind Fiber — caps the **entire request header block at 4 KiB by default**. Requests whose headers exceed that limit are rejected with:

> **HTTP 431 "Request Header Fields Too Large"**

…before the application code ever runs. This manifests as:

- Only `/`, `/favicon.ico`, `/static/sw.js` failing (the assets a browser requests on page load, each carrying the full cookie header)
- **No error in the Koffan logs** (fasthttp rejects the request during parsing, before the handler)
- Intermittent behavior: clearing cookies helps temporarily, then large cookie headers grow back and trigger 431 again

## Fix

Make the request read buffer size (which also caps the header block size) configurable via a new `HTTP_READ_BUFFER_SIZE` environment variable, defaulting to **16 KiB** instead of the too-small 4 KiB default.

```go
readBufferSize := 16384 // 16 KiB default
if v := os.Getenv("HTTP_READ_BUFFER_SIZE"); v != "" {
    if n, err := strconv.Atoi(v); err == nil && n > 0 {
        readBufferSize = n
    } else {
        log.Printf("Invalid HTTP_READ_BUFFER_SIZE %q, using default %d", v, readBufferSize)
    }
}

app := fiber.New(fiber.Config{
    Views:         engine,
    ViewsLayout:   "layout",
    ReadBufferSize: readBufferSize,
})
```

Also documents the new variable in the README environment variables table.

## Verification

- `go vet ./...` — clean
- `go build ./...` — succeeds
- `go test ./...` — all tests pass

Self-hosters behind SSO can set `HTTP_READ_BUFFER_SIZE` (e.g. `65536`) in their compose file instead of clearing cookies repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)