### PR TITLE
Fix:  Toggle show completed destroying the sortable/drag-drop binding

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1525,8 +1525,9 @@ function shoppingList() {
                 console.error('[Uncertain] Failed:', error);
             }
         },
-
+        // replaced with fix for the toggle and drag controls.  
         // Toggle show/hide completed items for current list
+        //...existing code...
         async toggleShowCompleted(listId) {
             this.markLocalAction('list_updated');
             try {
@@ -1535,6 +1536,10 @@ function shoppingList() {
                 const html = await resp.text();
                 document.getElementById('sections-list').innerHTML = html;
                 this.showCompleted = !this.showCompleted;
+                // Reinitialize drag-and-drop after DOM update
+                this.$nextTick(() => {
+                    this.initMobileSortable();
+                });
             } catch (e) {
                 console.error('Failed to toggle show completed:', e);
             }

--- a/static/app.js
+++ b/static/app.js
@@ -1527,7 +1527,6 @@ function shoppingList() {
         },
         // replaced with fix for the toggle and drag controls.  
         // Toggle show/hide completed items for current list
-        //...existing code...
         async toggleShowCompleted(listId) {
             this.markLocalAction('list_updated');
             try {


### PR DESCRIPTION
There is not a bug request for this topic, but I can certainly create one if necessary.  

**Problem:**  When in the list view, if a user clicks the "show bought items" the ability to drag items no longer works until the page is refreshed manually.  This due to the DOM updating after the toggle is pressed which destroys the sortable/drag‑and‑drop bindings

**Solution:**  Reinitialize the drag-drop feature after the toggle completes.  

add the following to the async toggleShowCompleted(listId) 

```
// Reinitialize drag-and-drop after DOM update
                this.$nextTick(() => {
                    this.initMobileSortable();
                });
```

The complete block would now be as follows.

```
         // replaced with fix for the toggle and drag controls.  
        // Toggle show/hide completed items for current list
        async toggleShowCompleted(listId) {
            this.markLocalAction('list_updated');
            try {
                const resp = await fetch(`/lists/${listId}/toggle-completed`, { method: 'POST' });
                if (!resp.ok) throw new Error(resp.statusText);
                const html = await resp.text();
                document.getElementById('sections-list').innerHTML = html;
                this.showCompleted = !this.showCompleted;
                // Reinitialize drag-and-drop after DOM update
                this.$nextTick(() => {
                    this.initMobileSortable();
                });
            } catch (e) {
                console.error('Failed to toggle show completed:', e);
            }

```